### PR TITLE
wait until textEntry is available before opening connections

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -258,9 +258,23 @@ ApplicationWindow {
         id: welcomeDialog
         WelcomeDialog {
             property bool __isWelcomeDialog: true
-            onAccepted: window.openConnections()
+            onAccepted: openConnectionsTimer.start()
             Component.onCompleted: NetworkSession.enabled = false
             Component.onDestruction: NetworkSession.enabled = true
+        }
+    }
+
+    Timer {
+        // If connection gets connected faster than page is loading
+        // command sending will fail. So we wait a bit.
+        id: openConnectionsTimer
+        interval: 100
+        onTriggered: {
+            if (typeof currentPage.textEntry === "undefined") {
+                openConnectionsTimer.start()
+            } else {
+                window.openConnections()
+            }
         }
     }
 


### PR DESCRIPTION
When accepting welcome page, connections are opened. If connections have commands to send, they are sent with currentPage.textEntry.sendLines() function.
If connections are opened quickly enough, currentPage is still welcome page, and there is no textEntry object, thus sending network commands fail.
this will open connections only after currentPage is such that has textEntry object.