### PR TITLE
Add option to hide topic messages on channel buffers

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -215,6 +215,12 @@ ApplicationWindow {
     }
 
     ConfigurationValue {
+       id: topicMessagesConfig
+       key: "/apps/harbour-communi/settings/topicmessages"
+       defaultValue: true
+    }
+
+    ConfigurationValue {
        id: notifyConfig
        key: "/apps/harbour-communi/settings/notify"
        defaultValue: true

--- a/qml/settings/settings.qml
+++ b/qml/settings/settings.qml
@@ -68,6 +68,12 @@ Page {
     }
 
     ConfigurationValue {
+       id: topicMessagesConfig
+       key: "/apps/harbour-communi/settings/topicmessages"
+       defaultValue: true
+    }
+
+    ConfigurationValue {
        id: notifyConfig
        key: "/apps/harbour-communi/settings/notify"
        defaultValue: true
@@ -115,6 +121,14 @@ Page {
                 value: eventsLimitConfig.value
                 onValueChanged: eventsLimitConfig.value = value
                 valueText: value === 0 ? qsTr("Unlimited") : qsTr("%1 users").arg(value)
+            }
+
+            TextSwitch {
+                width: parent.width
+                text: qsTr("Show topic messages")
+                description: qsTr("Specifies whether channel topic messages are shown when entering a channel.")
+                checked: topicMessagesConfig.value
+                onCheckedChanged: topicMessagesConfig.value = checked
             }
 
             SectionHeader { text: qsTr("Font") }

--- a/qml/view/BufferPage.qml
+++ b/qml/view/BufferPage.qml
@@ -139,6 +139,7 @@ Page {
             model: MessageFilter {
                 source: storage
                 showEvents: !!eventsConfig.value && (!eventsLimitConfig.value || userModel.count < eventsLimitConfig.value)
+                showTopicMessages: !!topicMessagesConfig.value
             }
 
             delegate: ListItem {

--- a/src/app/messagefilter.h
+++ b/src/app/messagefilter.h
@@ -36,6 +36,7 @@ class MessageFilter : public QSortFilterProxyModel
     Q_OBJECT
     Q_PROPERTY(QObject* source READ source WRITE setSource)
     Q_PROPERTY(bool showEvents READ showEvents WRITE setShowEvents NOTIFY showEventsChanged)
+    Q_PROPERTY(bool showTopicMessages READ showTopicMessages WRITE setShowTopicMessages NOTIFY showTopicMessagesChanged)
 
 public:
     MessageFilter(QObject* parent = 0);
@@ -46,14 +47,19 @@ public:
     bool showEvents() const;
     void setShowEvents(bool show);
 
+    bool showTopicMessages() const;
+    void setShowTopicMessages(bool show);
+
 signals:
     void showEventsChanged();
+    void showTopicMessagesChanged();
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const;
 
 private:
     bool m_events;
+    bool m_topicMessages;
 };
 
 #endif // MESSAGEFILTER_H


### PR DESCRIPTION
This is a suggestion for #131 to hide topic messages in channel buffers. This patch modifies `MessageFilter` to filter a few more commands, in particular `Names` and `Numeric` messages. This might be too much, but I did not find a direct way to filter more specific `Numeric` messages (without changing `MessageModel`).

So I consider this PR as a basis for discussion :)