### PR TITLE
Hide own join message

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -215,6 +215,12 @@ ApplicationWindow {
     }
 
     ConfigurationValue {
+       id: topicMessagesConfig
+       key: "/apps/harbour-communi/settings/topicmessages"
+       defaultValue: true
+    }
+
+    ConfigurationValue {
        id: notifyConfig
        key: "/apps/harbour-communi/settings/notify"
        defaultValue: true

--- a/qml/settings/settings.qml
+++ b/qml/settings/settings.qml
@@ -68,6 +68,12 @@ Page {
     }
 
     ConfigurationValue {
+       id: topicMessagesConfig
+       key: "/apps/harbour-communi/settings/topicmessages"
+       defaultValue: true
+    }
+
+    ConfigurationValue {
        id: notifyConfig
        key: "/apps/harbour-communi/settings/notify"
        defaultValue: true
@@ -115,6 +121,14 @@ Page {
                 value: eventsLimitConfig.value
                 onValueChanged: eventsLimitConfig.value = value
                 valueText: value === 0 ? qsTr("Unlimited") : qsTr("%1 users").arg(value)
+            }
+
+            TextSwitch {
+                width: parent.width
+                text: qsTr("Show topic messages")
+                description: qsTr("Specifies whether channel topic messages are shown when entering a channel.")
+                checked: topicMessagesConfig.value
+                onCheckedChanged: topicMessagesConfig.value = checked
             }
 
             SectionHeader { text: qsTr("Font") }

--- a/qml/view/BufferPage.qml
+++ b/qml/view/BufferPage.qml
@@ -139,6 +139,7 @@ Page {
             model: MessageFilter {
                 source: storage
                 showEvents: !!eventsConfig.value && (!eventsLimitConfig.value || userModel.count < eventsLimitConfig.value)
+                showTopicMessages: !!topicMessagesConfig.value
             }
 
             delegate: ListItem {

--- a/src/app/messagefilter.cpp
+++ b/src/app/messagefilter.cpp
@@ -88,7 +88,7 @@ bool MessageFilter::filterAcceptsRow(int sourceRow, const QModelIndex& sourcePar
         case IrcMessage::Join:
         case IrcMessage::Part:
         case IrcMessage::Quit:
-            return index.data(OwnRole).toBool();
+            return m_events;
         case IrcMessage::Topic:
         case IrcMessage::Numeric:
         case IrcMessage::Names:

--- a/src/app/messagefilter.h
+++ b/src/app/messagefilter.h
@@ -36,6 +36,7 @@ class MessageFilter : public QSortFilterProxyModel
     Q_OBJECT
     Q_PROPERTY(QObject* source READ source WRITE setSource)
     Q_PROPERTY(bool showEvents READ showEvents WRITE setShowEvents NOTIFY showEventsChanged)
+    Q_PROPERTY(bool showTopicMessages READ showTopicMessages WRITE setShowTopicMessages NOTIFY showTopicMessagesChanged)
 
 public:
     MessageFilter(QObject* parent = 0);
@@ -46,14 +47,19 @@ public:
     bool showEvents() const;
     void setShowEvents(bool show);
 
+    bool showTopicMessages() const;
+    void setShowTopicMessages(bool show);
+
 signals:
     void showEventsChanged();
+    void showTopicMessagesChanged();
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const;
 
 private:
     bool m_events;
+    bool m_topicMessages;
 };
 
 #endif // MESSAGEFILTER_H


### PR DESCRIPTION
This is also related to #131. The old implementation hides join/part messages except for oneself. This change hides all such messages, because on reconnect they will be shown in each channel buffer (and do not provide much information).