### PR TITLE
[TASK] Document install sources

### DIFF
--- a/INSTALL.org
+++ b/INSTALL.org
@@ -21,6 +21,18 @@
    Builds submitted for Harbour are also build on the community OBS.
    These builds can be found at [[https://build.sailfishos.org/package/show/home:Thaodan:forharbour:communi/communi-sailfish][home:Thaodan:forharbour:communi/communi-sailfish]].
 
+
+* Harbour
+  The for-Harbour builds mentioned above are submitted through Harbour and once approved
+  can be installed from there.
+
+* OpenRepos
+  OpenRepos also contains the same Harbour builds but skips the QA process and thous appear
+  earlier.
+
+  OpenRepos packages can be found [[https://openrepos.net/content/thaodan/communi][here]].
+
+
 * Building locally from source
 ** Prerequisites
 

--- a/INSTALL.org
+++ b/INSTALL.org
@@ -43,6 +43,7 @@
 *** Python-CairoSVG
 
  To build the app need to have python-cairosvg available in your target.
+
  One source for that is for example [[https://github.com/sailfishos-chum/main][SailfishOS-CHUM]], to add it read the SailfishOS wiki
  under [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Deploying_packages/#deploying-from-repository][Deploying_packages/#deploying-from-repository]].
 
@@ -50,18 +51,7 @@
 
  Building Communi-Sailish is not different to any Sailfish App.
 
- To build the app you just run sfkdk (Sailfish SDK):
-
- #+begin_src sh
- sfkdk build
- #+end_src
-
- Or mb2 (Platform SDK):
-
- #+begin_src sh
- mb2 build
- #+end_src
-
+ To build the app you just run ~sfkdk build~ (Sailfish SDK) or ~mb2 build~ (Platform SDK):
 
 ** Installing
 

--- a/INSTALL.org
+++ b/INSTALL.org
@@ -1,36 +1,59 @@
 #+TITLE: Building and installing Communi-Sailfish
-* Prerequisites
 
-Before you can anything else you should first [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Installation/][install]][fn:1] the Sailfish SDK (or Platform SDK) and have
-read the Sailfish Wiki about building [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Building_packages][packages]][fn:2].
+* Building on/Installing from the community OBS
+  Communi can be build individually on the community OBS and is already done so.
+
+  We build on the OBS using the OBS service tar_git as explained in
+  the SailfishOS wiki under [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Building_packages/#tar_git-packaging-structure][Building_packages/#tar_git-packaging-structure]].
+
+** SailfishOS-Chum
+   Communi is present in SailfishOS-Chum and can be installed from the chum repositories.
+
+   Please read [[https://github.com/sailfishos-chum/main#users-guide=][SailfishOS-Chum/main#users-guide]] to do so.
+
+   Communi is present in Chum two versions:
+
+   - Chum :: Latest stable version (same as in Harbour)
+
+   - Chum-testing :: Latest nightly version build from master (read [[./docs/chum.org]] for more information)
+
+** (For-)Harbour
+   Builds submitted for Harbour are also build on the community OBS.
+   These builds can be found at [[https://build.sailfishos.org/package/show/home:Thaodan:forharbour:communi/communi-sailfish][home:Thaodan:forharbour:communi/communi-sailfish]].
+
+* Building locally from source
+** Prerequisites
+
+ Before you can anything else you should first [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Installation/][install]][fn:1] the Sailfish SDK (or Platform SDK) and have
+ read the Sailfish Wiki about building [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Building_packages][packages]][fn:2].
 
 
-** Python-CairoSVG
+*** Python-CairoSVG
 
-To build the app need to have python-cairosvg available in your target.
-One source for that is for example [[https://github.com/sailfishos-chum/main][SailfishOS-CHUM]], to add it read the SailfishOS wiki
-under [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Deploying_packages/#deploying-from-repository][Deploying_packages/#deploying-from-repository]].
+ To build the app need to have python-cairosvg available in your target.
+ One source for that is for example [[https://github.com/sailfishos-chum/main][SailfishOS-CHUM]], to add it read the SailfishOS wiki
+ under [[https://docs.sailfishos.org/Tools/Sailfish_SDK/Deploying_packages/#deploying-from-repository][Deploying_packages/#deploying-from-repository]].
 
-* Building
+** Building
 
-Building Communi-Sailish is not different to any Sailfish App.
+ Building Communi-Sailish is not different to any Sailfish App.
 
-To build the app you just run sfkdk (Sailfish SDK):
+ To build the app you just run sfkdk (Sailfish SDK):
 
-#+begin_src sh
-sfkdk build
-#+end_src
+ #+begin_src sh
+ sfkdk build
+ #+end_src
 
-Or mb2 (Platform SDK):
+ Or mb2 (Platform SDK):
 
-#+begin_src sh
-mb2 build
-#+end_src
+ #+begin_src sh
+ mb2 build
+ #+end_src
 
 
-* Installing
+** Installing
 
-Follow: https://docs.sailfishos.org/Tools/Sailfish_SDK/Deploying_packages/
+ Follow: https://docs.sailfishos.org/Tools/Sailfish_SDK/Deploying_packages/
 
 * Footnotes
 

--- a/README.org
+++ b/README.org
@@ -2,12 +2,12 @@
 
 The first and foremost IRC client for Sailfish, based on the Communi IRC framework.
 
-* Building
+* Building or Installing
 
 Please read [[./INSTALL.org]]
 
 * Contact
 
 + IRC channel: #communi on [[ircs://irc.libera.chat/communi][irc.libera.chat]]
-+ Mailing list: communi-sailfish@googlegroups.com
++ Mailing list: mailto:communi-sailfish@googlegroups.com
 + Bug reports: https://github.com/communi/communi-sailfish/issues


### PR DESCRIPTION
There's  [./INSTALL.org](https://github.com/communi/communi-sailfish/blob/master/INSTALL.org)
file now that documents the process of creating local builds.

However there are multiple other ways to install Communi:
+ Chum, Chum-Testing
+ Openrepos
+ Harbour

These sources should also be listed in the INSTALL.org file.